### PR TITLE
refactor: alerts support id, class selectors

### DIFF
--- a/projects/clr-extension/package.json
+++ b/projects/clr-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clr-extension",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The library is designed to augment the capabilities of the Clarity library by providing a set of reusable components built on top of clarity components.",
   "author": "Guanghui Wang <guanghui-wang@foxmail.com>",
   "peerDependencies": {

--- a/projects/clr-extension/src/lib/components/alerts/alerts.service.spec.ts
+++ b/projects/clr-extension/src/lib/components/alerts/alerts.service.spec.ts
@@ -22,10 +22,7 @@ describe('AlertsService', () => {
   });
 
   it('should add and sanitize alert', (done) => {
-    const mockAlert: Alert = new Alert('<strong>Test Alert</strong>', {
-      targetId: 'testId',
-      onTargetClick: jasmine.createSpy(),
-    });
+    const mockAlert: Alert = new Alert('<strong>Test Alert</strong>');
 
     service.addAlert(mockAlert);
 
@@ -40,7 +37,7 @@ describe('AlertsService', () => {
 
   it('should delete alert and unregister event', (done) => {
     const mockAlert: Alert = new Alert('Test Alert <button id="testId">Click</button>', {
-      targetId: 'testId',
+      targetSelector: '#testId',
       onTargetClick: jasmine.createSpy(),
     });
 
@@ -54,8 +51,8 @@ describe('AlertsService', () => {
   });
 
   it('should clear alerts', (done) => {
-    const mockAlert: Alert = new Alert('Test Alert <button id="testId">Click</button>', {
-      targetId: 'testId',
+    const mockAlert: Alert = new Alert('Test Alert <button class="test">Click</button>', {
+      targetSelector: '.test',
       onTargetClick: jasmine.createSpy(),
     });
 

--- a/projects/clr-extension/src/lib/components/alerts/alerts.service.ts
+++ b/projects/clr-extension/src/lib/components/alerts/alerts.service.ts
@@ -50,11 +50,11 @@ export class AlertsService {
    */
   private registerEvent(alert: Alert) {
     setTimeout(() => {
-      if (alert.targetId && alert.onTargetClick) {
-        const element = document.getElementById(alert.targetId);
+      if (alert.targetSelector && alert.onTargetClick) {
+        const element = document.querySelector(alert.targetSelector);
         element?.addEventListener('click', alert.onTargetClick, false);
       }
-    }, 0);
+    }, 2000);
   }
 
   /**
@@ -62,8 +62,8 @@ export class AlertsService {
    * @param alert Alert to be unregistered
    */
   private unregisterEvent(alert: Alert) {
-    if (alert.targetId && alert.onTargetClick) {
-      const element = document.getElementById(alert.targetId);
+    if (alert.targetSelector && alert.onTargetClick) {
+      const element = document.getElementById(alert.targetSelector);
       element?.removeEventListener('click', alert.onTargetClick, false);
     }
   }

--- a/projects/clr-extension/src/lib/models/alert.model.ts
+++ b/projects/clr-extension/src/lib/models/alert.model.ts
@@ -16,7 +16,7 @@ export class Alert {
    * @param {AlertType} [options.alertType='danger'] - The type of the alert. Defaults to 'danger'.
    * @param {boolean} [options.isAppLevel=true] - Indicates whether the alert is at the application level. Defaults to true.
    * @param {() => void} [options.onTargetClick] - A onTargetClick function to be executed when the a target inside the alert is clicked.
-   * @param {string} [options.targetId] - The ID of the target element inside the alert, such as button or a link.
+   * @param {string} [options.targetSelector] - The DOM selector of the target element inside the alert, such as button or a link.
    */
   constructor(
     public content: string,
@@ -24,12 +24,12 @@ export class Alert {
       alertType = 'danger',
       isAppLevel = true,
       onTargetClick,
-      targetId,
+      targetSelector,
     }: {
       alertType?: AlertType;
       isAppLevel?: boolean;
       onTargetClick?: () => void;
-      targetId?: string;
+      targetSelector?: string;
     } = {},
   ) {
     /**
@@ -52,10 +52,10 @@ export class Alert {
     this.isAppLevel = isAppLevel;
 
     /**
-     * The ID of the clickable target element such as a button or a link.
+     * The class or ID of the clickable target element such as a button or a link.
      * @member {string | undefined}
      */
-    this.targetId = targetId;
+    this.targetSelector = targetSelector;
 
     /**
      * A onTargetClick function to be executed when the target is clicked.
@@ -84,10 +84,10 @@ export class Alert {
   isAppLevel: boolean;
 
   /**
-   * The ID of the clickable target element such as a button or a link.
+   * The class or ID of the clickable target element such as a button or a link.
    * @member {string | undefined}
    */
-  targetId?: string;
+  targetSelector?: string;
 
   /**
    * A onTargetClick function to be executed when the target is clicked.

--- a/projects/demo-application/src/app/clr-lib/pages/alerts-demo/alerts-demo.component.html
+++ b/projects/demo-application/src/app/clr-lib/pages/alerts-demo/alerts-demo.component.html
@@ -34,9 +34,9 @@
     <p>
       At times, you might find the need to incorporate a button or link within an alert's content. Managing the
       onTargetClick for button clicks or navigating to an internal route through link clicks involves specifying the
-      <code>onTargetClick</code> function and <code>targetId</code> in the second options parameter. The
-      <code>targetId</code> corresponds to the ID of the clickable element, while the <code>onTargetClick</code> denotes
-      the function to be executed upon clicking the element.
+      <code>onTargetClick</code> function and <code>targetSelector</code> in the second options parameter. The
+      <code>targetSelector</code> corresponds to the selector of the clickable element (ID, class, etc), while the
+      <code>onTargetClick</code> denotes the function to be executed upon clicking the element.
     </p>
     <app-code-block [code]="advancedCode" />
   </section>

--- a/projects/demo-application/src/app/clr-lib/pages/alerts-demo/alerts-demo.component.ts
+++ b/projects/demo-application/src/app/clr-lib/pages/alerts-demo/alerts-demo.component.ts
@@ -28,7 +28,7 @@ export class AlertsDemoComponent implements OnInit {
     this.alertsService.addAlert(
       new Alert(
         'Alert with a button. <button type="button" class="btn btn-sm btn-outline" id="click-target">Click Me</button>',
-        {alertType: 'info', targetId: 'click-target', onTargetClick: this.clickMe},
+        {alertType: 'info', targetSelector: '#click-target', onTargetClick: this.clickMe},
       ),
     );
   }
@@ -70,8 +70,8 @@ clearAlerts() {
   advancedCode = highlight(`
 this.alertsService.addAlert(
   new Alert(
-    'Alert with a button. <button type="button" class="btn btn-sm btn-outline" id="click-target">Click Me</button>',
-    {alertType: 'info', targetId: 'click-target', onTargetClick: this.clickMe},
+    'Alert with a button. <button type="button" class="btn btn-sm btn-outline" class="click-target">Click Me</button>',
+    {alertType: 'info', targetSelector: '.click-target', onTargetClick: this.clickMe},
   ),
 );
 


### PR DESCRIPTION
1. Previous only id selector is supported. This PR changes getElementById to querySelector, allowing more selectors. 
2. Delay 2s to bind the click event.