### PR TITLE
refactor(operator): refactor start-with-tap operator

### DIFF
--- a/projects/ngx-extension/src/lib/operators/start-with-tap.operator.ts
+++ b/projects/ngx-extension/src/lib/operators/start-with-tap.operator.ts
@@ -1,4 +1,4 @@
-import {Observable, of, switchMap, tap} from 'rxjs';
+import {Observable} from 'rxjs';
 
 /**
  * Operator that taps into a callback before the source Observable starts emitting values.
@@ -9,9 +9,8 @@ import {Observable, of, switchMap, tap} from 'rxjs';
  * @returns An RxJS operator function that taps into the callback and then switchMaps to the source Observable.
  */
 export function startWithTap<T>(callback: () => void) {
-  return (source: Observable<T>) =>
-    of({}).pipe(
-      tap(callback), // Tap into the callback function
-      switchMap(() => source), // Switch to the source Observable after tapping
-    );
+  return (source: Observable<T>) => {
+    callback();
+    return source;
+  };
 }


### PR DESCRIPTION
* update the UT case of startWithTap operator with the multi-emit observable to demonstrate the callback timing
* simplify startWithTap to remove `of` function and other RxJS operators